### PR TITLE
Fix handling of deprecations with an empty reason.

### DIFF
--- a/pyls_memestra/plugin.py
+++ b/pyls_memestra/plugin.py
@@ -20,7 +20,7 @@ def format_text(deprecated_uses, diagnostics):
             'start': {'line': lineno - 1, 'character': colno},
             'end': {'line': lineno - 1, 'character': colno + len(fname)},
         }
-        if reason != "reason":
+        if reason and reason != "reason":
             diagnostics.append({
                 'source': 'memestra',
                 'range': err_range,


### PR DESCRIPTION
This fixes a crash that occurs when 'reason' has a value of 'None'. I ran into this issue because on my machine Memestra reports no deprecation reason when the deprecated code was imported from another module. I suspect this is either a bug in my setup or an issue with Memestra. In any case, I figured it made sense to submit a PR to fix the crash.