### PR TITLE
Add support for configuring the plugin, improve tests

### DIFF
--- a/pyls_memestra/plugin.py
+++ b/pyls_memestra/plugin.py
@@ -1,3 +1,4 @@
+import os
 from pyls import hookimpl, lsp
 from memestra import memestra
 
@@ -6,14 +7,40 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 @hookimpl
-def pyls_lint(document):
+def pyls_settings():
+    return {
+        "plugins": {
+            "pyls-memestra": {
+                "enabled": True,
+                "recursive": False,
+                "decorator_module": "deprecated",
+                "decorator_function": "deprecated",
+                "reason_keyword": "reason",
+                "cache_dir": None,
+                "additional_search_paths": []
+            }
+        }
+    }
+
+@hookimpl
+def pyls_lint(config, document):
+    settings = config.plugin_settings('pyls-memestra',
+                                      document_path=document.path)
     diagnostics = []
+    search_paths = [os.path.dirname(os.path.abspath(document.path))]
+    search_paths.extend(settings.get('additional_search_paths'))
     with open(document.path, 'r') as code:
-        deprecated_uses = memestra(code, decorator=("deprecated", "deprecated"),
-            reason_keyword="reason")
+        deprecated_uses = memestra(
+            code,
+            decorator=(settings.get('decorator_module'),
+                       settings.get('decorator_function')),
+            reason_keyword=settings.get('reason_keyword'),
+            recursive=settings.get('recursive'),
+            cache_dir=settings.get('cache_dir'),
+            search_paths=search_paths)
         diagnostics = format_text(deprecated_uses, diagnostics)
     return diagnostics
- 
+
 def format_text(deprecated_uses, diagnostics):
     for fname, fd, lineno, colno, reason in deprecated_uses:
         err_range = {

--- a/tests/data/cache/076aaa16906a1eec82d6d77607fdaa1e6e369ef6305e42c4196a8bea57bb0d61
+++ b/tests/data/cache/076aaa16906a1eec82d6d77607fdaa1e6e369ef6305e42c4196a8bea57bb0d61
@@ -1,0 +1,5 @@
+deprecated:
+- 'bar:cached'
+generator: manual
+name: cachetest
+version: 1

--- a/tests/data/cachetest.py
+++ b/tests/data/cachetest.py
@@ -1,0 +1,2 @@
+def bar():
+    pass

--- a/tests/data/file.py
+++ b/tests/data/file.py
@@ -1,0 +1,10 @@
+import deprecated
+from importtest import imported
+
+@deprecated.deprecated('deprecated at some point')
+def foo(): pass
+
+def bar():
+    foo()
+
+imported()

--- a/tests/data/importtest.py
+++ b/tests/data/importtest.py
@@ -1,0 +1,4 @@
+import deprecated
+
+@deprecated.deprecated(reason='test reason')
+def imported(): pass

--- a/tests/data/testpackage/__init__.py
+++ b/tests/data/testpackage/__init__.py
@@ -1,0 +1,1 @@
+from .bar import bar

--- a/tests/data/testpackage/bar.py
+++ b/tests/data/testpackage/bar.py
@@ -1,0 +1,5 @@
+import deprecated
+
+@deprecated.deprecated("nested")
+def bar():
+    pass

--- a/tests/file.py
+++ b/tests/file.py
@@ -1,9 +1,0 @@
-import decorator
-
-@decorator.deprecated
-def foo(): pass
-
-def bar():
-    foo()
-
-foo()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,57 +1,179 @@
+import os
+import tempfile
 from pathlib import Path
+from unittest.mock import Mock
+from copy import deepcopy
 import pytest
 
 from memestra import memestra, nbmemestra
-# from nbmemestra import nbmemestra
-from pyls_memestra.plugin import format_text
-from pyls.workspace import Document
+from pyls_memestra.plugin import format_text, pyls_lint, pyls_settings
+from pyls import uris
+from pyls.config.config import Config
+from pyls.workspace import Workspace, Document
 
 here = Path(__file__).parent
+data = here / "data"
 
-def test_pyls_file():
-    path = here / "file.py"
-    with open(path, 'r') as code:
-        deprecated_uses = memestra(code, decorator=("decorator", "deprecated"))
-        assert deprecated_uses == [('foo',
-            '/home/mariana/Development/pyls-memestra/tests/file.py',
-            7, 4),
-            ('foo',
-            '/home/mariana/Development/pyls-memestra/tests/file.py',
-            9, 0)]
+@pytest.fixture
+def config(tmpdir):
+    config = Config(uris.from_fs_path(str(tmpdir)), {}, 0, {})
+    config.update(pyls_settings())
+    return config
+
+@pytest.fixture
+def workspace(tmpdir, config):
+    ws = Workspace(uris.from_fs_path(str(tmpdir)), Mock())
+    ws._config = config
+    return ws
+
+@pytest.yield_fixture
+def document(workspace):
+    temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+
+    def write_doc(text):
+        temp_file.write(text)
+        temp_file.close()
+        doc = Document(uris.from_fs_path(temp_file.name), workspace)
+        return doc
+
+    yield write_doc
+    os.remove(temp_file.name)
+
+def build_diagnostic(name, start, end, reason, source="memestra", severity=3):
+    if reason is None:
+        message = name + " is deprecated."
+    else:
+        message = name + " is deprecated. " + reason
+
+    return {
+            "source": source,
+            "range": {
+                "start": {
+                    "line": start[0],
+                    "character": start[1]
+                },
+                "end": {
+                    "line": end[0],
+                    "character": end[1]
+                }
+            },
+            "message": message,
+            "severity": severity
+        }
+
+def update_setting(config, name, value):
+    settings = deepcopy(config._settings)
+    settings["plugins"]["pyls-memestra"][name] = value
+    config.update(settings)
+
+def test_basic(workspace, config):
+    doc = Document(uris.from_fs_path(str(data / "file.py")), workspace)
+    diagnostics = pyls_lint(config, doc)
+
+    assert diagnostics == [
+        build_diagnostic("foo", (7, 4), (7, 7), "deprecated at some point"),
+        build_diagnostic("imported", (9, 0), (9, 8), "test reason"),
+    ]
+
+def test_decorator_name(workspace, config, document):
+    doc = document("""
+import bogus
+
+@bogus.deprecateme("nope")
+def foo():
+    pass
+
+foo()
+""")
+    update_setting(config, "decorator_module", "bogus")
+    update_setting(config, "decorator_function", "deprecateme")
+    diagnostics = pyls_lint(config, doc)
+
+    assert diagnostics == [
+        build_diagnostic("foo", (7, 0), (7, 3), "nope"),
+    ]
+
+def test_reason_keyword(workspace, config, document):
+    doc = document("""
+import deprecated
+
+@deprecated.deprecated(excuse="too old")
+def foo():
+    pass
+
+foo()
+""")
+    update_setting(config, "reason_keyword", "excuse")
+    diagnostics = pyls_lint(config, doc)
+
+    assert diagnostics == [
+        build_diagnostic("foo", (7, 0), (7, 3), "too old"),
+    ]
+
+def test_empty_reason(workspace, config, document):
+    doc = document("""
+import deprecated
+
+@deprecated.deprecated
+def foo():
+    pass
+
+foo()
+""")
+    update_setting(config, "reason_keyword", "excuse")
+    diagnostics = pyls_lint(config, doc)
+
+    assert diagnostics == [
+        build_diagnostic("foo", (7, 0), (7, 3), None),
+    ]
+
+@pytest.mark.skip("This test needs improvements to memestra imports")
+def test_recursive(workspace, config, document):
+    doc = document("""
+from testpackage import bar
+
+bar()
+""")
+    update_setting(config, "recursive", True)
+    diagnostics = pyls_lint(config, doc)
+
+    assert diagnostics == [
+        build_diagnostic("bar", (3, 0), (3, 3), "nested"),
+    ]
+
+def test_search_paths(workspace, config, document):
+    doc = document("""
+from bar import bar
+
+bar()
+""")
+    update_setting(config, "additional_search_paths",
+                   [str(data / "testpackage")])
+    diagnostics = pyls_lint(config, doc)
+
+    assert diagnostics == [
+        build_diagnostic("bar", (3, 0), (3, 3), "nested"),
+    ]
+
+def test_cache_dir(workspace, config, document):
+    doc = document("""
+from cachetest import bar
+
+bar()
+""")
+    update_setting(config, "additional_search_paths", [str(data)])
+    update_setting(config, "cache_dir", str(data / "cache"))
+    diagnostics = pyls_lint(config, doc)
+
+    assert diagnostics == [
+        build_diagnostic("bar", (3, 0), (3, 3), "cached"),
+    ]
 
 def test_pyls_format_text_syntax():
-    keywords = [('foo', '', 7, 4), ('foo', '', 9, 0)]
+    keywords = [('foo', '', 7, 4, 'reason1'), ('foo', '', 9, 0, 'reason2')]
 
     result = format_text(keywords, [])
     assert result == [
-   {
-      "source":"memestra",
-      "range":{
-         "start":{
-            "line":6,
-            "character":4
-         },
-         "end":{
-            "line":6,
-            "character":3
-         }
-      },
-      "message":"foo is deprecated.",
-      "severity":3
-   },
-   {
-      "source":"memestra",
-      "range":{
-         "start":{
-            "line":8,
-            "character":0
-         },
-         "end":{
-            "line":8,
-            "character":3
-         }
-      },
-      "message":"foo is deprecated.",
-      "severity":3
-   }
-]
+        build_diagnostic("foo", (6, 4), (6, 7), 'reason1'),
+        build_diagnostic("foo", (8, 0), (8, 3), 'reason2')
+    ]


### PR DESCRIPTION
Allows the options passed to memestra to be configured via the pyls configuration system. These settings can be set either from the workspace path or from the editor.

This PR requires https://github.com/QuantStack/memestra/pull/45