### PR TITLE
Logger setup no longer sets the root log level to debug

### DIFF
--- a/pyls_memestra/plugin.py
+++ b/pyls_memestra/plugin.py
@@ -3,8 +3,7 @@ from pyls import hookimpl, lsp
 from memestra import memestra
 
 import logging
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 @hookimpl
 def pyls_settings():


### PR DESCRIPTION
```python
logger = logging.getLogger()
logger.setLevel(logging.DEBUG)
```
Will return the root logger for the python language server, and set the default log level to debug. This change configures a new logger for the plugin and leaves the debug level at the default level.