### PR TITLE
don't distribute a "tests" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://github.com/QuantStack/pyls-memestra",
     author="marimeireles",
     author_email="mariana@psychonautgirl.space",
-    packages=['pyls_memestra', "tests"],
+    packages=find_package(".", exclude=["tests*"]),
     install_requires=open("requirements.txt").read().splitlines(),
     entry_points={"pyls": ["pyls_memestra = pyls_memestra.plugin"]},
     classifiers=[


### PR DESCRIPTION
Hi folks! Thanks again for this!

Ran into some `ClobberWarnings` with this. Basically the `tests` package is useless, as a number of other packages _also_ distribute `tests`, and nobody can ever really `import tests` outside of _their_ test environment. 

This PR just uses the already imported `find_packages`, but explicitly excludes `tests`!

Also, as a heads up: stuff is warming up on the [modern successor](https://github.com/python-ls/python-ls) to `@palantir/python-language-server`... soon-to-be featuring `jedi 0.18` compatibility, better performance, etc.