### PR TITLE
Skip cache testing on windows

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -156,7 +156,7 @@ bar()
         build_diagnostic("bar", (3, 0), (3, 3), "nested"),
     ]
 
-@pytest.mark.skipif(sys.platform == 'windows', reason='failing on windows')
+@pytest.mark.skipif(sys.platform == 'win32', reason='failing on windows')
 def test_cache_dir(workspace, config, document):
     doc = document("""
 from cachetest import bar

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -155,6 +155,7 @@ bar()
         build_diagnostic("bar", (3, 0), (3, 3), "nested"),
     ]
 
+@pytest.mark.skipif(sys.platform == 'windows', reason='failing on windows')
 def test_cache_dir(workspace, config, document):
     doc = document("""
 from cachetest import bar


### PR DESCRIPTION
The test of the use of the cache doesn't work on Windows.
I don't know why that is, but I suspect the cache isn't being hit
because of the key being different for some reason related to Windows,
maybe line endings?
