### PR TITLE
fix UnicodeEncodeError

### DIFF
--- a/pyls_memestra/plugin.py
+++ b/pyls_memestra/plugin.py
@@ -24,14 +24,14 @@ def pylsp_settings():
 
 @hookimpl
 def pylsp_lint(config, document):
-    print("pyls_lint 🐔")
+    # print("pyls_lint 🐔")
     settings = config.plugin_settings('pyls-memestra',
                                       document_path=document.path)
     diagnostics = []
     search_paths = [os.path.dirname(os.path.abspath(document.path))]
     search_paths.extend(settings.get('additional_search_paths'))
     try:
-        with open(document.path, 'r') as code:
+        with open(document.path, 'r', encoding="utf-8") as code:
             deprecated_uses = memestra(
                 code,
                 decorator=(settings.get('decorator_module'),


### PR DESCRIPTION
in my case

```sh
LSP-pylsp:   File "C:\Users\zangwill\AppData\Local\Programs\Python\Python310\lib\site-packages\pyls_memestra\plugin.py", line 27, in pylsp_lint
LSP-pylsp:     print("pyls_lint \U0001f414")
LSP-pylsp: UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f414' in position 10: illegal multibyte sequence
```

```sh
LSP-pylsp:   File "C:\Users\zangwill\AppData\Local\Programs\Python\Python310\lib\site-packages\pyls_memestra\plugin.py", line 36, in pylsp_lint
LSP-pylsp:     deprecated_uses = memestra(
LSP-pylsp:   File "C:\Users\zangwill\AppData\Local\Programs\Python\Python310\lib\site-packages\memestra\memestra.py", line 421, in memestra
LSP-pylsp:     module, syntax_errors = frilouz.parse(ast.parse, file_descriptor.read())
LSP-pylsp: UnicodeDecodeError: 'gbk' codec can't decode byte 0xaf in position 985: illegal multibyte sequence
```