### PR TITLE
Add deprecated tag from LSP 3.15

### DIFF
--- a/pyls_memestra/plugin.py
+++ b/pyls_memestra/plugin.py
@@ -6,6 +6,11 @@ import logging
 logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
 
+# TODO: use lsp.DiagnosticTag once https://github.com/python-lsp/python-lsp-server/pull/142 is merged
+class DiagnosticTag:
+    Unnecessary = 1
+    Deprecated = 2
+
 @hookimpl
 def pylsp_settings():
     return {
@@ -58,6 +63,7 @@ def format_text(deprecated_uses, diagnostics):
                 'range': err_range,
                 'message': fname + " is deprecated. " + reason,
                 'severity': lsp.DiagnosticSeverity.Information,
+                'tags': [DiagnosticTag.Deprecated],
             })
         else:
             diagnostics.append({
@@ -65,5 +71,6 @@ def format_text(deprecated_uses, diagnostics):
                 'range': err_range,
                 'message': fname + " is deprecated.",
                 'severity': lsp.DiagnosticSeverity.Information,
+                'tags': [DiagnosticTag.Deprecated],
             })
     return diagnostics

--- a/pyls_memestra/plugin.py
+++ b/pyls_memestra/plugin.py
@@ -35,6 +35,14 @@ def pylsp_lint(config, document):
     diagnostics = []
     search_paths = [os.path.dirname(os.path.abspath(document.path))]
     search_paths.extend(settings.get('additional_search_paths'))
+    supported_tags = set(
+        config.capabilities
+        .get('textDocument', {})
+        .get('publishDiagnostics', {})
+        .get('tagSupport', {})
+        .get('valueSet', set())
+    )
+
     try:
         with open(document.path, 'r') as code:
             deprecated_uses = memestra(
@@ -45,32 +53,34 @@ def pylsp_lint(config, document):
                 recursive=settings.get('recursive'),
                 cache_dir=settings.get('cache_dir'),
                 search_paths=search_paths)
-            diagnostics = format_text(deprecated_uses, diagnostics)
+            diagnostics = format_text(deprecated_uses, diagnostics, supported_tags)
     except SyntaxError as e:
         logger.error('Syntax error at {} - {} ({})', e.line, e.column, e.message)
         raise e
     return diagnostics
 
-def format_text(deprecated_uses, diagnostics):
+def format_text(deprecated_uses, diagnostics, supported_tags=None):
+    if supported_tags is None:
+        supported_tags = set()
+    tags = [DiagnosticTag.Deprecated]
     for fname, fd, lineno, colno, reason in deprecated_uses:
         err_range = {
             'start': {'line': lineno - 1, 'character': colno},
             'end': {'line': lineno - 1, 'character': colno + len(fname)},
         }
         if reason and reason != "reason":
-            diagnostics.append({
-                'source': 'memestra',
-                'range': err_range,
-                'message': fname + " is deprecated. " + reason,
-                'severity': lsp.DiagnosticSeverity.Information,
-                'tags': [DiagnosticTag.Deprecated],
-            })
+            message = fname + " is deprecated. " + reason
         else:
-            diagnostics.append({
-                'source': 'memestra',
-                'range': err_range,
-                'message': fname + " is deprecated.",
-                'severity': lsp.DiagnosticSeverity.Information,
-                'tags': [DiagnosticTag.Deprecated],
-            })
+            message = fname + " is deprecated."
+
+        diagnostic = {
+            'source': 'memestra',
+            'range': err_range,
+            'message': message,
+            'severity': lsp.DiagnosticSeverity.Information,
+        }
+
+        if DiagnosticTag.Deprecated in supported_tags:
+            diagnostic['tags'] = tags
+        diagnostics.append(diagnostic)
     return diagnostics

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -40,7 +40,9 @@ def document(workspace):
     yield write_doc
     os.remove(temp_file.name)
 
-def build_diagnostic(name, start, end, reason, source="memestra", severity=3):
+def build_diagnostic(name, start, end, reason, source="memestra", severity=3, tags=None):
+    if tags is None:
+        tags = [2]
     if reason is None:
         message = name + " is deprecated."
     else:
@@ -59,7 +61,8 @@ def build_diagnostic(name, start, end, reason, source="memestra", severity=3):
                 }
             },
             "message": message,
-            "severity": severity
+            "severity": severity,
+            "tags": tags
         }
 
 def update_setting(config, name, value):


### PR DESCRIPTION
Closes #52; the end result with https://github.com/jupyter-lsp/jupyterlab-lsp/pull/736 is:

![Screenshot from 2021-12-30 16-27-32](https://user-images.githubusercontent.com/5832902/147770295-9a1e4822-99bd-41f3-8c5a-f4a84e6a7587.png)

For now I added the `DiagnosticTag` enum in plugin.py but once https://github.com/python-lsp/python-lsp-server/pull/142 is merged and released we can use `lsp.DiagnosticTag` instead (or ideally try to import it and fallback to `DiagnosticTag` for a while until the new version of pylsp is widely adopted).